### PR TITLE
refactor(ExecTransform): accept a script file instead of a filepath

### DIFF
--- a/transform.go
+++ b/transform.go
@@ -63,7 +63,7 @@ func newTransform(node *p2p.QriNode, ds *dataset.Dataset, infile cafs.File) *tra
 	}
 }
 
-// ExecFile executes a transformation against a starlark file located at filepath, giving back an EntryReader of resulting data
+// ExecFile executes a transformation against a starlark script file, giving back an EntryReader of resulting data
 // ExecFile modifies the given dataset pointer. At bare minimum it will set transformation details, but starlark scripts can modify
 // many parts of the dataset pointer, including meta, structure, and transform
 func ExecFile(ds *dataset.Dataset, script, bodyFile cafs.File, opts ...func(o *ExecOpts)) (cafs.File, error) {

--- a/transform_test.go
+++ b/transform_test.go
@@ -1,18 +1,31 @@
 package startf
 
 import (
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	starlark "github.com/google/skylark"
+	"github.com/qri-io/cafs"
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/dataset/dsio"
 )
 
+func scriptFile(t *testing.T, path string) *cafs.Memfile {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return cafs.NewMemfileBytes(path, data)
+}
+
 func TestExecFile(t *testing.T) {
 	ds := &dataset.Dataset{}
-	body, err := ExecFile(ds, "testdata/tf.star", nil)
+	script := scriptFile(t, "testdata/tf.star")
+
+	body, err := ExecFile(ds, script, nil)
 	if err != nil {
 		t.Error(err.Error())
 		return
@@ -48,7 +61,8 @@ func TestExecFile2(t *testing.T) {
 	}))
 
 	ds := &dataset.Dataset{}
-	_, err := ExecFile(ds, "testdata/fetch.star", nil, func(o *ExecOpts) {
+	script := scriptFile(t, "testdata/fetch.star")
+	_, err := ExecFile(ds, script, nil, func(o *ExecOpts) {
 		o.Globals["test_server_url"] = starlark.String(s.URL)
 	})
 


### PR DESCRIPTION
this drops the requirement that callers of `ExecTransform` create an actual file. Should also be much more performant on larger transform scripts. Needed for some upstream changes I'm planning on qri-io/qri