### PR TITLE
feat(OutWriter): accept writer param on ExecTransform to record script stdout

### DIFF
--- a/testdata/tf.star
+++ b/testdata/tf.star
@@ -1,4 +1,5 @@
 
 def transform(ds, ctx):
+  print("hello world!")
   ds.set_body([1, 1.5, False, 'a','b','c', { "a" : 1, "b" : True }, [1,2]])
   return ds

--- a/transform_test.go
+++ b/transform_test.go
@@ -1,6 +1,7 @@
 package startf
 
 import (
+	"bytes"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -25,13 +26,24 @@ func TestExecScript(t *testing.T) {
 	ds := &dataset.Dataset{}
 	script := scriptFile(t, "testdata/tf.star")
 
-	body, err := ExecScript(ds, script, nil)
+	stdout := &bytes.Buffer{}
+	body, err := ExecScript(ds, script, nil, SetOutWriter(stdout))
 	if err != nil {
 		t.Error(err.Error())
 		return
 	}
 	if ds.Transform == nil {
 		t.Error("expected transform")
+	}
+
+	output, err := ioutil.ReadAll(stdout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expect := `🤖  running transform...
+hello world!`
+	if string(output) != expect {
+		t.Errorf("stdout mismatch. expected: '%s', got: '%s'", expect, string(output))
 	}
 
 	entryReader, err := dsio.NewEntryReader(ds.Structure, body)


### PR DESCRIPTION
This is part of a set of PRs that'll get script output printing on the frontend.

Providing an `io.Writer` value as an option to `ExecTransform` will now record output to the provided writer, allowing callers to capture a record of the script's output as it's being executed. Output is automatically piped to both Node.LocalStreams _and_ OutWriter if both are provided. A convenience method: `SetOutWriter` provides plug-and-play config for a given writer. It'll be a common pattern to allocate a *bytes.Buffer and pass that to SetOutWriter(buf), then read back the buffered output.