### PR TITLE
fix(set_meta): use GoString to set meta keys

### DIFF
--- a/ds/dataset.go
+++ b/ds/dataset.go
@@ -64,7 +64,7 @@ func (d *Dataset) SetMeta(thread *starlark.Thread, _ *starlark.Builtin, args sta
 		return nil, err
 	}
 
-	key := keyx.String()
+	key := keyx.GoString()
 
 	if err := d.checkField("meta", "key"); err != nil {
 		return starlark.None, err


### PR DESCRIPTION
this was causing ds.set_meta("number_of_cats", 5) to set dataset.meta.["\"number_of_cats\""]: 5 (note the extra set of quotes)