### PR TITLE
fix(ds.set_body): calling set_body should not affect dataset structure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
           name: Publish coverage info to codecov.io
           command: bash <(curl -s https://codecov.io/bash)
       - store_artifacts:
-        path: /tmp/test-results
-        destination: raw-test-output
+          path: /tmp/test-results
+          destination: raw-test-output
       - store_test_results:
           path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,14 @@ jobs:
             - /go/src/gx/
       - run:
           name: Run Tests
-          command: go test -v -race -coverprofile=coverage.txt -covermode=atomic
+          command: |
+            trap "go-junit-report <${TEST_RESULTS}/go-test.out > ${TEST_RESULTS}/go-test-report.xml" EXIT
+            ./.circleci/cover.test.sh | tee ${TEST_RESULTS}/go-test.out
       - run:
           name: Publish coverage info to codecov.io
           command: bash <(curl -s https://codecov.io/bash)
+      - store_artifacts:
+        path: /tmp/test-results
+        destination: raw-test-output
+      - store_test_results:
+          path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/qri-io/startf
     docker:
-      - image: circleci/golang:1.11
-        environment:
-          GOLANG_ENV: test
+      - image: circleci/golang:1.11.5
     environment:
       TEST_RESULTS: /tmp/test-results
     steps:

--- a/.circleci/cover.test.sh
+++ b/.circleci/cover.test.sh
@@ -2,7 +2,7 @@
 
 set -e
 echo "" > coverage.txt
-go test -v -race -coverprofile=profile.out -covermode=atomic github.com/qri-io/dsdiff
+go test -v -race -coverprofile=profile.out -covermode=atomic github.com/qri-io/startf
 if [ -f profile.out ]; then
   cat profile.out >> coverage.txt
   rm profile.out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+<a name="0.3.0"></a>
+# [0.3.0](https://github.com/qri-io/startf/compare/v0.2.1...v0.3.0) (2019-03-07)
+
+a few small tweaks, and a version bump to match [starlib](https://github.com/qri-io/starlib)
+
+### Bug Fixes
+
+* **ds.set_body:** don't assign schemas when using set_body ([df4742b](https://github.com/qri-io/startf/commit/df4742b))
+* **set_meta:** use GoString to set meta keys ([af7a305](https://github.com/qri-io/startf/commit/af7a305))
+
+
+### Features
+
+* **ds:** structure component getter & setter methods ([0dc0d41](https://github.com/qri-io/startf/commit/0dc0d41))
+* **ds.set_body:** accept data_format argument in conjunction with raw=True ([3f12e40](https://github.com/qri-io/startf/commit/3f12e40))
+
+
+### BREAKING CHANGES
+
+* **ds:** ds.set_schema is removed, use ds.set_structure instead.
+
+
+
 <a name="0.2.1"></a>
 # [0.2.1](https://github.com/qri-io/startf/compare/v0.2.0...v0.2.1) (2019-02-05)
 

--- a/ds/dataset.go
+++ b/ds/dataset.go
@@ -206,9 +206,6 @@ func (d *Dataset) SetBody(thread *starlark.Thread, _ *starlark.Builtin, args sta
 		Schema: sch,
 	}
 
-	if d.ds.Structure == nil {
-		d.ds.Structure = st
-	}
 	w, err := dsio.NewEntryBuffer(st)
 	if err != nil {
 		return starlark.None, err

--- a/ds/dataset.go
+++ b/ds/dataset.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"sync"
 
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/dataset/dsio"
@@ -13,6 +14,28 @@ import (
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
 )
+
+// ModuleName defines the expected name for this Module when used
+// in starlark's load() function, eg: load('dataset.star', 'dataset')
+const ModuleName = "dataset.star"
+
+var (
+	once          sync.Once
+	datasetModule starlark.StringDict
+)
+
+// LoadModule loads the base64 module.
+// It is concurrency-safe and idempotent.
+func LoadModule() (starlark.StringDict, error) {
+	once.Do(func() {
+		datasetModule = starlark.StringDict{
+			"dataset": starlarkstruct.FromStringDict(starlarkstruct.Default, starlark.StringDict{
+				"new": starlark.NewBuiltin("new", New),
+			}),
+		}
+	})
+	return datasetModule, nil
+}
 
 // MutateFieldCheck is a function to check if a dataset field can be mutated
 // before mutating a field, dataset will call MutateFieldCheck with as specific
@@ -26,9 +49,16 @@ type Dataset struct {
 	check MutateFieldCheck
 }
 
-// NewDataset creates a dataset object
+// NewDataset creates a dataset object, intended to be called from go-land to prepare datasets
+// for handing to other functions
 func NewDataset(ds *dataset.Dataset, check MutateFieldCheck) *Dataset {
 	return &Dataset{ds: ds, check: check}
+}
+
+// New creates a new dataset from starlark land
+func New(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	d := &Dataset{ds: &dataset.Dataset{}}
+	return d.Methods(), nil
 }
 
 // Dataset returns the underlying dataset
@@ -39,10 +69,11 @@ func (d *Dataset) Dataset() *dataset.Dataset {
 // Methods exposes dataset methods as starlark values
 func (d *Dataset) Methods() *starlarkstruct.Struct {
 	return starlarkstruct.FromStringDict(starlarkstruct.Default, starlark.StringDict{
-		"set_meta":   starlark.NewBuiltin("set_meta", d.SetMeta),
-		"set_schema": starlark.NewBuiltin("set_schema", d.SetSchema),
-		"get_body":   starlark.NewBuiltin("get_body", d.GetBody),
-		"set_body":   starlark.NewBuiltin("set_body", d.SetBody),
+		"set_meta":      starlark.NewBuiltin("set_meta", d.SetMeta),
+		"get_structure": starlark.NewBuiltin("get_structure", d.GetStructure),
+		"set_structure": starlark.NewBuiltin("set_structure", d.SetStructure),
+		"get_body":      starlark.NewBuiltin("get_body", d.GetBody),
+		"set_body":      starlark.NewBuiltin("set_body", d.SetBody),
 	})
 }
 
@@ -82,10 +113,29 @@ func (d *Dataset) SetMeta(thread *starlark.Thread, _ *starlark.Builtin, args sta
 	return starlark.None, d.ds.Meta.Set(key, val)
 }
 
-// SetSchema sets the dataset schema field
-func (d *Dataset) SetSchema(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+// GetStructure gets a dataset structure component
+func (d *Dataset) GetStructure(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if d.ds.Structure == nil {
+		return starlark.None, nil
+	}
+
+	data, err := json.Marshal(d.ds.Structure)
+	if err != nil {
+		return starlark.None, err
+	}
+
+	jsonData := map[string]interface{}{}
+	if err := json.Unmarshal(data, &jsonData); err != nil {
+		return starlark.None, err
+	}
+
+	return util.Marshal(jsonData)
+}
+
+// SetStructure sets the dataset structure component
+func (d *Dataset) SetStructure(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var valx starlark.Value
-	if err := starlark.UnpackPositionalArgs("set_schema", args, kwargs, 1, &valx); err != nil {
+	if err := starlark.UnpackPositionalArgs("set_structure", args, kwargs, 1, &valx); err != nil {
 		return nil, err
 	}
 
@@ -93,17 +143,11 @@ func (d *Dataset) SetSchema(thread *starlark.Thread, _ *starlark.Builtin, args s
 		return starlark.None, err
 	}
 
-	rs := map[string]interface{}{}
-	if err := json.Unmarshal([]byte(valx.String()), &rs); err != nil {
+	d.ds.Structure = &dataset.Structure{}
+	if err := json.Unmarshal([]byte(valx.String()), d.ds.Structure); err != nil {
 		return starlark.None, err
 	}
 
-	if d.ds.Structure == nil {
-		d.ds.Structure = &dataset.Structure{
-			Format: "json",
-		}
-	}
-	d.ds.Structure.Schema = rs
 	return starlark.None, nil
 }
 

--- a/ds/dataset_test.go
+++ b/ds/dataset_test.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"testing"
 
+	"go.starlark.net/resolve"
 	"go.starlark.net/starlark"
+	"go.starlark.net/starlarktest"
 )
 
 func TestCheckFields(t *testing.T) {
@@ -23,11 +25,37 @@ func TestCheckFields(t *testing.T) {
 		t.Errorf("expected fieldErr, got: %s", err)
 	}
 
-	if _, err := ds.SetSchema(thread, nil, starlark.Tuple{starlark.String("wut")}, nil); err != fieldErr {
+	if _, err := ds.SetStructure(thread, nil, starlark.Tuple{starlark.String("wut")}, nil); err != fieldErr {
 		t.Errorf("expected fieldErr, got: %s", err)
 	}
 }
 
-func TestSetBody(t *testing.T) {
-	t.Skip("TODO (b5)")
+func TestFile(t *testing.T) {
+	resolve.AllowFloat = true
+	thread := &starlark.Thread{Load: newLoader()}
+	starlarktest.SetReporter(thread, t)
+
+	// Execute test file
+	_, err := starlark.ExecFile(thread, "testdata/test.star", nil, nil)
+	if err != nil {
+		if ee, ok := err.(*starlark.EvalError); ok {
+			t.Error(ee.Backtrace())
+		} else {
+			t.Error(err)
+		}
+	}
+}
+
+// load implements the 'load' operation as used in the evaluator tests.
+func newLoader() func(thread *starlark.Thread, module string) (starlark.StringDict, error) {
+	return func(thread *starlark.Thread, module string) (starlark.StringDict, error) {
+		switch module {
+		case ModuleName:
+			return LoadModule()
+		case "assert.star":
+			return starlarktest.LoadAssertModule()
+		}
+
+		return nil, fmt.Errorf("invalid module")
+	}
 }

--- a/ds/testdata/test.star
+++ b/ds/testdata/test.star
@@ -1,0 +1,37 @@
+load('assert.star', 'assert')
+load('dataset.star', 'dataset')
+
+ds = dataset.new()
+
+assert.eq(ds.set_meta("foo", "bar"), None)
+
+
+assert.eq(ds.get_structure(), None)
+
+st = {
+  'format' : 'json', 
+  'schema' : { 'type' : 'array' } 
+}
+
+exp = {
+  'schema': {
+    'type': 'array'
+  },
+  'errCount': 0, 
+  'format': 'json', 
+  'qri': 'st:0'
+}
+
+assert.eq(ds.set_structure(st), None)
+assert.eq(ds.get_structure(), exp)
+
+
+bd = [[1,2,3]]
+bd_obj = {'a': [1,2,3]}
+
+assert.eq(ds.set_body(bd_obj), None)
+assert.eq(ds.set_body(bd), None)
+assert.eq(ds.set_body("[[1,2,3]]", raw=True), None)
+
+# TODO - haven't thought through this yet
+assert.eq(ds.get_body(), bd)

--- a/startf.go
+++ b/startf.go
@@ -2,4 +2,4 @@ package startf
 
 // Version is the current version of this startf, this version number will be written
 // with each transformation exectution
-const Version = "0.2.2-dev"
+const Version = "0.3.0"

--- a/testdata/tf.star
+++ b/testdata/tf.star
@@ -1,5 +1,6 @@
 
 def transform(ds, ctx):
   print("hello world!")
+  ds.set_structure({ 'format': 'json', 'schema': { 'type' : 'array' }})
   ds.set_body([1, 1.5, False, 'a','b','c', { "a" : 1, "b" : True }, [1,2]])
   return ds

--- a/transform.go
+++ b/transform.go
@@ -116,8 +116,6 @@ func ExecScript(ds *dataset.Dataset, opts ...func(o *ExecOpts)) error {
 	tr := io.TeeReader(script, buf)
 	pipeScript := qfs.NewMemfileReader(script.FileName(), tr)
 
-	// buffer for script output
-
 	t := &transform{
 		node:      o.Node,
 		ds:        ds,


### PR DESCRIPTION
ds.set_body was creating the erronious side effect of setting structure, which meant that the returned dataset from executing a transform would contain a non-nil `Structure`. That structure was then considered a change, which would clobber the previous dataset structure on every transform execution. No bueno.

This means structure is now preserved, and will need to be explicitly set in transform scripts, which I think is a good thing.