### PR TITLE
fix(GetBody): if there is no Body file, return starlark.None

### DIFF
--- a/ds/dataset.go
+++ b/ds/dataset.go
@@ -191,8 +191,9 @@ func (d *Dataset) GetBody(thread *starlark.Thread, _ *starlark.Builtin, args sta
 	}
 
 	if d.ds.BodyFile() == nil {
-		return valx, nil
+		return starlark.None, nil
 	}
+
 	if d.ds.Structure == nil {
 		return starlark.None, fmt.Errorf("error: no structure for previous dataset")
 	}

--- a/startf.go
+++ b/startf.go
@@ -2,4 +2,4 @@ package startf
 
 // Version is the current version of this startf, this version number will be written
 // with each transformation exectution
-const Version = "0.3.2"
+const Version = "0.3.3-dev"


### PR DESCRIPTION
Currently, if you try to `ds.get_body()` on a dataset that has no body, it will return `nil` instead of `None`, which causes the transform to error. This fixes that bug!