### PR TITLE
fix(ds.GetBody): don't override the default

### DIFF
--- a/ds/dataset.go
+++ b/ds/dataset.go
@@ -191,7 +191,10 @@ func (d *Dataset) GetBody(thread *starlark.Thread, _ *starlark.Builtin, args sta
 	}
 
 	if d.ds.BodyFile() == nil {
-		return starlark.None, nil
+		if valx == nil {
+			return starlark.None, nil
+		}
+		return valx, nil
 	}
 
 	if d.ds.Structure == nil {


### PR DESCRIPTION
My bad!!!!

Didn't fully read the api of the `GetBody` function and accidentally wrote over the default. 