### PR TITLE
fix(Get*): Accessors get previous version until set_*

### DIFF
--- a/ds/dataset_test.go
+++ b/ds/dataset_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/qri-io/dataset"
 	"go.starlark.net/resolve"
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarktest"
@@ -15,6 +16,7 @@ func TestCheckFields(t *testing.T) {
 		return fieldErr
 	}
 	ds := NewDataset(nil, allErrCheck)
+	ds.SetMutable(&dataset.Dataset{})
 	thread := &starlark.Thread{}
 
 	if _, err := ds.SetBody(thread, nil, starlark.Tuple{starlark.String("data")}, nil); err != fieldErr {

--- a/testdata/meta_title.star
+++ b/testdata/meta_title.star
@@ -1,0 +1,6 @@
+def transform(ds, ctx):
+  meta = ds.get_meta()
+  if not meta:
+    ds.set_body(['no title'])
+  else:
+    ds.set_body(['title: %s' % meta['title']])


### PR DESCRIPTION
Methods on datasets, like get_body and get_meta etc, return data from the previous version, until the corresponding set_* method is called. Datasets are, by default, read-only, unless the SetMutable method is called with a writable dataset.Dataset pointer.