### PR TITLE
better set_body

### DIFF
--- a/ds/dataset.go
+++ b/ds/dataset.go
@@ -248,9 +248,9 @@ func (d *Dataset) GetBody(thread *starlark.Thread, _ *starlark.Builtin, args sta
 	if err != nil {
 		return starlark.None, err
 	}
-	provider.SetBodyFile(qfs.NewMemfileBytes("data.json", data))
+	provider.SetBodyFile(qfs.NewMemfileBytes("body.json", data))
 
-	rr, err := dsio.NewEntryReader(provider.Structure, qfs.NewMemfileBytes("data.json", data))
+	rr, err := dsio.NewEntryReader(provider.Structure, qfs.NewMemfileBytes("body.json", data))
 	if err != nil {
 		return starlark.None, fmt.Errorf("error allocating data reader: %s", err)
 	}
@@ -310,7 +310,7 @@ func (d *Dataset) SetBody(thread *starlark.Thread, _ *starlark.Builtin, args sta
 			return starlark.None, fmt.Errorf("expected data for '%s' format to be a string", df)
 		}
 
-		d.write.SetBodyFile(qfs.NewMemfileBytes(fmt.Sprintf("data.%s", df), []byte(string(str))))
+		d.write.SetBodyFile(qfs.NewMemfileBytes(fmt.Sprintf("body.%s", df), []byte(string(str))))
 		d.modBody = true
 		d.bodyCache = nil
 		return starlark.None, nil

--- a/ds/dataset_test.go
+++ b/ds/dataset_test.go
@@ -228,7 +228,7 @@ bat,3,meh
 			},
 		},
 	}
-	ds.SetBodyFile(qfs.NewMemfileBytes("data.csv", []byte(text)))
+	ds.SetBodyFile(qfs.NewMemfileBytes("body.csv", []byte(text)))
 
 	d := NewDataset(ds, nil)
 	d.SetMutable(&dataset.Dataset{

--- a/ds/doc.go
+++ b/ds/doc.go
@@ -1,0 +1,28 @@
+/*Package ds defines the qri dataset object within starlark
+
+  outline: ds
+    ds defines the qri dataset object within starlark. it's loaded by default
+    in the qri runtime
+
+    types:
+      Dataset
+        a qri dataset. Datasets can be either read-only or read-write. By default datasets are read-write
+        methods:
+          set_meta(meta dict)
+            set dataset meta component
+          get_meta() dict|None
+            get dataset meta component
+          get_structure() dict|None
+            get dataset structure component if one is defined
+          set_structure(structure) structure
+            set dataset structure component
+          get_body() dict|list|None
+            get dataset body component if one is defined
+          set_body(data dict|list, parse_as? string) body
+            set dataset body component. set_body has only one optional argument: 'parse_as', which defaults to the
+            empty string. By default qri assumes the data value provided to set_body is an iterable starlark data
+            structure (tuple, set, list, dict). When parse_as is set, set_body assumes the provided body value will
+            be a string of serialized structured data in the given format. valid parse_as values are "json", "csv",
+            "cbor", "xlsx".
+*/
+package ds

--- a/ds/testdata/test.star
+++ b/ds/testdata/test.star
@@ -32,7 +32,7 @@ bd_obj = {'a': [1,2,3]}
 
 assert.eq(ds.set_body(bd_obj), None)
 assert.eq(ds.set_body(bd), None)
-assert.eq(ds.set_body("[[1,2,3]]", raw=True), None)
+assert.eq(ds.set_body("[[1,2,3]]", parse_as="json"), None)
 
 # TODO - haven't thought through this yet
 assert.eq(ds.get_body(), bd)

--- a/ds/testdata/test.star
+++ b/ds/testdata/test.star
@@ -38,7 +38,7 @@ assert.eq(ds.set_body("[[1,2,3]]", parse_as="json"), None)
 assert.eq(ds.get_body(), bd)
 
 # csv_ds is a global variable provided by dataset_test.go
-# "cycling" csv data through starlark shouldn't have significant effects on the 
+# round-tripping csv data through starlark shouldn't have significant effects on the 
 # encoded data. whitespace is *not* significant.
 # csv data is one of the harder formats, where there header row must be preserved
 csv_ds.set_body(csv_ds.get_body())

--- a/ds/testdata/test.star
+++ b/ds/testdata/test.star
@@ -36,3 +36,13 @@ assert.eq(ds.set_body("[[1,2,3]]", raw=True), None)
 
 # TODO - haven't thought through this yet
 assert.eq(ds.get_body(), bd)
+
+# csv_ds is a global variable provided by dataset_test.go
+# "cycling" csv data through starlark shouldn't have significant effects on the 
+# encoded data. whitespace is *not* significant.
+# csv data is one of the harder formats, where there header row must be preserved
+csv_ds.set_body(csv_ds.get_body())
+
+expect_data = [["foo",1,"true"], ["bar",2,"false"], ["bat",3,"meh"]]
+assert.eq(expect_data, csv_ds.get_body())
+assert.eq(csv_ds.get_structure()['format'], 'csv')


### PR DESCRIPTION
set_body wasn't doing the right thing when it comes to determining the destination datset structure for writing a body. We now inherit structure from existing dataset data, and only fall back to json if no structure exists.

The general problem here is a separation of concerns between data in the starlark runtime and dataset serialization formats. Those should always be seperate, with set_body giving qri the data it wants serialized, or skipping serialization with `ds.set_body(data, parse_as='format'`